### PR TITLE
Fix bugs of test_Inference_polytrope.ipynb

### DIFF
--- a/Test_Case/test_Inference_polytrope.ipynb
+++ b/Test_Case/test_Inference_polytrope.ipynb
@@ -26,16 +26,15 @@
     }
    ],
    "source": [
-    "#Package we need:\n",
     "import InferenceWorkflow.prior as prior\n",
     "import numpy as np\n",
     "import ultranest\n",
+    "import ultranest.stepsampler\n",
     "\n",
-    "from TOVsolver.unit import g_cm_3, dyn_cm_2, km, Msun, e0\n",
-    "from TOVsolver.maxium_central_density import maxium_central_density\n",
-    "from TOVsolver.solver_code import solveTOV2\n",
     "import EOSgenerators.Polytrope_EOS as Polytrope\n",
-    "from TOVsolver.maxium_central_density import maxium_central_density"
+    "from TOVsolver.maxium_central_density import maxium_central_density\n",
+    "from TOVsolver.solver_code import solveTOV\n",
+    "from TOVsolver.unit import g_cm_3, dyn_cm_2, km, Msun, e0"
    ]
   },
   {
@@ -72,7 +71,7 @@
    "source": [
     "### Set up prior\n",
     "\n",
-    "Next step, we need to set up the prior, first use parameters array to specify the variable name, should be consistent with what you need to call them. Second, we need to define a list to store some intermediate parameters derived from `prior_transform`. These parameters will be used in `likelihood_transform`, specifically 'd_max' in this case.\n",
+    "Next step, we need to set up the prior, first use parameters array to specify the variable name, should be consistent with what you need to call them. Second, we need to define a list to store some intermediate parameters derived from `prior_transform`. These parameters may be used in `likelihood_transform` or somewhere else and it will be stored in the final result, specifically 'd_max' in this case.\n",
     "    \n",
     "Define a prior transform function to define prior. Cube are set of random number from 0 to 1. This prior setting is standard set-up of UltraNest package, since we are using `UltraNest` to do nest-sampling. We provided \n",
     "\n",
@@ -143,17 +142,17 @@
     "            k = pt / (rho_s[i-1]**gamma_s[-1])\n",
     "            pt = k*rho_s[i]**gamma_s[-1]\n",
     "\n",
-    "    rho_ts = np.array([para[3],para[4],para[5],para[6]])\n",
-    "    gammas = np.array([para[0],para[1],para[2]])\n",
+    "    gammas = np.array([para[3],para[4],para[5],para[6]])\n",
+    "    rho_ts= np.array([para[0],para[1],para[2]])\n",
     "    theta = np.append(gammas, rho_ts)\n",
-    "    pres = Polytrope.compute_EOS(eps_core, theta)[0]\n",
+    "    pres = Polytrope.compute_EOS(eps_core, theta)\n",
     "    eps = np.hstack((eps_crust, eps_core))\n",
     "    pres = np.hstack((pres_crust, pres))\n",
     "    \n",
     "    d_max = maxium_central_density(eps, pres, cent_densitys)\n",
     "    para[7:] = 14.3 + (np.log10(d_max / g_cm_3) - 14.3) * cube[7:]\n",
     "\n",
-    "    return np.append(para, d_max)"
+    "    return np.append(para, d_max) # d_max is in natural unit, but d1,d2,d3 are the result of taking the logarithm of density in g_cm3"
    ]
   },
   {
@@ -212,10 +211,9 @@
     "f1 = np.log(1/(R_sigma*M_sigma*(np.sqrt(2*np.pi))**2)).sum()\n",
     "\n",
     "def from_para_to_MR_points(theta, densitys):\n",
-    "    pres = Polytrope.compute_EOS(eps_core, theta)[0]\n",
+    "    pres = Polytrope.compute_EOS(eps_core, theta)\n",
     "    eps = np.hstack((eps_crust, eps_core))\n",
     "    pres = np.hstack((pres_crust, pres))\n",
-    "\n",
     "    unique_pressure_indices = np.unique(pres, return_index=True)[1]\n",
     "    unique_pressure = pres[np.sort(unique_pressure_indices)]\n",
     "\n",
@@ -225,7 +223,7 @@
     "    MR_points = []\n",
     "    for dens in densitys:\n",
     "        try:\n",
-    "            result = solveTOV2(dens, pres[20], eos, inveos)\n",
+    "            result = solveTOV(dens, pres[20], eos, inveos)\n",
     "            MR_points.append(result)\n",
     "        except OverflowError as e:\n",
     "            MR_points.append([0,0])\n",
@@ -234,11 +232,11 @@
     "def likelihood_transform(theta):\n",
     "    gammas = np.array([theta[3],theta[4],theta[5],theta[6]])\n",
     "    rho_ts = np.array([theta[0],theta[1],theta[2]])\n",
-    "    d_s = 10 ** np.array(theta[7:]) * g_cm_3\n",
+    "    d_s = 10 ** np.array(theta[7:-1]) * g_cm_3\n",
     "\n",
     "    theta = np.append(gammas, rho_ts)\n",
     "    Ms, Rs = from_para_to_MR_points(theta, d_s).T\n",
-    "    \n",
+    "\n",
     "    # In order to drop the unpysical parameters more efficiently, I used super Gaussian function here.\n",
     "    fm = np.where(Ms>3*Msun, -(Ms-2*Msun)**20, -(Ms-Mvalue)**2/(2*M_sigma**2))\n",
     "    fr = np.where(Rs>20*km, -(Rs-16*km)**20, -(Rs-Rvalue)**2/(2*R_sigma**2))\n",
@@ -355,19 +353,17 @@
    "source": [
     "step = 2 * len(parameters)\n",
     "live_point = 4000 # More parameters need more points.\n",
-    "max_calls = 500000 \n",
+    "max_calls = 500000 # In the example code, the result is Z=-5.7(23.50%), which means that the max_calls should be larger.\n",
     "\n",
-    "\n",
-    "sampler = ultranest.ReactiveNestedSampler(parameters, likelihood_transform, prior_transform, log_dir='output/output_11', derived_param_names=derived_param_names)\n",
+    "sampler = ultranest.ReactiveNestedSampler(parameters, likelihood_transform, prior_transform, log_dir='output/Polytrope_EOS', derived_param_names=derived_param_names)\n",
     "sampler.stepsampler = ultranest.stepsampler.SliceSampler(\n",
     "    nsteps=step,\n",
     "    generate_direction=ultranest.stepsampler.generate_mixture_random_direction,\n",
     "    # adaptive_nsteps=False,\n",
-    "    # max_nsteps=400,\n",
-    "    )\n",
+    "    # max_nsteps=400\n",
+    ")\n",
     "\n",
-    "result = sampler.run(min_num_live_points=live_point,\n",
-    "                     max_ncalls= max_calls)\n",
+    "result = sampler.run(min_num_live_points=live_point,max_ncalls= max_calls)\n",
     "flat_samples = sampler.results['samples']"
    ]
   }


### PR DESCRIPTION
In the previous version, this file

1. erroneously imported a non-existent function, `solveTOV2`, from `solver_code.py`, 
2. improperly called the `Polytrope_EOS` function, 
3. and neglected to import `ultranest.stepsampler`.

I have addressed and resolved these issues.